### PR TITLE
Fix token leak

### DIFF
--- a/sisAPI.py
+++ b/sisAPI.py
@@ -136,7 +136,9 @@ class sisAPI:
         
         try:
             self.access_token = self._getToken(username, password)
-            token_file = open(os.environ['HOME'] + '/.osiris_token', 'w')
+            token_file = open(os.open(os.environ['HOME'] + '/.osiris_token',
+                                      os.O_CREAT | os.O_WRONLY,
+                                      0o600), 'w')
             token_file.write(self.access_token)
             return True
         except:


### PR DESCRIPTION
The token file is created with the default permissions as limited by umask, which in most cases would result in it being world-readable. This is a very serious problem if you are on a true multi-user machine (maybe you use the script from lilo?), as any other user can just read your session token and impersonate you. On a personal machine this is not as grave, but still problematic, as all system processes can read the file, which makes attacks easier (no privilege escalation needed anymore).

Creating the file with proper permissions is easy, but there is more to it now: Recreating the file with proper permissions by logging in again reduces the threat of future leaks, but the old session is probably still valid, and has already been leaked. To fix this, signing in again should probably sign you out of the old session first, if it is still valid. It is probably a good idea in general to not leave sessions dangling.
I'll look up how to perform the logout and then add that. Maybe I should also add a warning when sisAPI finds the file existing with wrong permissions, recommending to log in again.